### PR TITLE
Fixes QA 3

### DIFF
--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -94,6 +94,12 @@ class UserService:
     @classmethod
     async def update(cls, session: AsyncSession, user_id: UUID, update_data: Dict[str, str]) -> Optional[User]:
         try:
+            # remove sensitive fields if its present to prevent updates from unauthorized users
+            sensitive_fields = {"role", "email_verified", "is_locked", "verification_token", "failed_login_attempts"}
+            for field in sensitive_fields:
+                if field in update_data:
+                    update_data.pop(field)
+
             # validated_data = UserUpdate(**update_data).dict(exclude_unset=True)
             validated_data = UserUpdatePublic(**update_data).model_dump(exclude_unset=True)
 


### PR DESCRIPTION
Service is now up-to-date in preventing any accidental updates from occurring to sensitive fields by users. Runtime validation is enforced by preventing sensitive fields in user update requests. Reliant on role checks in the API layer restricting access to only admins and managers. Including these security measures in these layers ensures these fields are truly secured. Fixes #5  